### PR TITLE
fix: only mount required esm dirs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,8 @@ jobs:
         ports:
           - '8080:8080'
         volumes:
-          - /home/runner/docker-storage/esmd:/esmd
+          - /home/runner/docker-storage/esmd/npm:/esmd/npm
+          - /home/runner/docker-storage/esmd/storage:/esmd/storage
 
       npm:
         image: verdaccio/verdaccio:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,8 @@ services:
     ports:
       - '8080:8080'
     volumes:
-      - ./docker-storage/esm/esmd:/esmd
+      - ./docker-storage/esm/npm:/esmd/npm
+      - ./docker-storage/esm/storage:/esmd/storage
   npm:
     image: verdaccio/verdaccio:latest
     ports:

--- a/templates/init/docker-compose.yml.mustache
+++ b/templates/init/docker-compose.yml.mustache
@@ -34,7 +34,8 @@ services:
     ports:
       - '{{esmPort}}:8080'
     volumes:
-      - {{esmStoragePath}}:/esmd
+      - {{esmStoragePath}}/npm:/esmd/npm
+      - {{esmStoragePath}}/storage:/esmd/storage
 
   npm:
     image: verdaccio/verdaccio:latest


### PR DESCRIPTION
The latest ESM.sh service is now using a different OS
and not always compiling on first load when mounting the bin drive.