### PR TITLE
chore(node): removing deprecated flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "npm run clean && tsc",
     "clean": "rimraf dist",
-    "esm.dev": "node --experimental-strip-types --no-warnings=ExperimentalWarning ./src/cli.ts",
+    "esm.dev": "node ./src/cli.ts",
     "prepare": "husky",
     "start": "docker compose up --detach --remove-orphans",
     "stop": "docker compose down",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --experimental-strip-types --no-warnings=ExperimentalWarning
+#!/usr/bin/env node
 import { runExit } from 'clipanion'
 import { WatchCommand } from './commands/WatchCommand.ts'
 import { RepublishCommand } from './commands/RepublishCommand.ts'


### PR DESCRIPTION
See https://nodejs.org/en/blog/release/v22.18.0

BREAKING CHANGE: Dropping support for Node<v22.18.0